### PR TITLE
Fix theme-next enable pjax cannot load script

### DIFF
--- a/index.js
+++ b/index.js
@@ -105,7 +105,7 @@ hexo.extend.filter.register('after_post_render', (data) => {
     .replace(/{{hbeWrongPassMessage}}/g, config.wrong_pass_message)
     .replace(/{{hbeWrongHashMessage}}/g, config.wrong_hash_message)
     .replace(/{{hbeMessage}}/g, config.message);
-  data.content += `<script src="${hexo.config.root}lib/hbe.js"></script><link href="${hexo.config.root}css/hbe.style.css" rel="stylesheet" type="text/css">`;
+  data.content += `<script data-pjax src="${hexo.config.root}lib/hbe.js"></script><link href="${hexo.config.root}css/hbe.style.css" rel="stylesheet" type="text/css">`;
   data.excerpt = data.more = config.abstract;
 
   return data;


### PR DESCRIPTION
使用 theme-next 主题并且开启了 pjax 功能后，页面将由 pjax 请求并替换，这种情况下 `<script>` 标签内的脚本不会被加载和执行，导致解密功能失效。

theme-next 有预留会在 pjax 加载完成后，找到页面上所有带 `data-pjax` 属性的 `<script>` 标签执行一次，因此可以利用这个机制加载解密脚本。