### PR TITLE
support theme-next refresh

### DIFF
--- a/lib/hbe.js
+++ b/lib/hbe.js
@@ -202,7 +202,7 @@ const knownPrefix = "<hbe-prefix></hbe-prefix>";
       });
 
       // support theme-next refresh
-      window.NexT && NexT.boot && NexT.boot.refresh();
+      window.NexT && NexT.boot && typeof NexT.boot.refresh === 'function' && NexT.boot.refresh();
 
       // TOC part
       var tocDiv = document.getElementById("toc-div");

--- a/lib/hbe.js
+++ b/lib/hbe.js
@@ -201,6 +201,9 @@ const knownPrefix = "<hbe-prefix></hbe-prefix>";
         }
       });
 
+      // support theme-next refresh
+      window.NexT && NexT.boot && NexT.boot.refresh();
+
       // TOC part
       var tocDiv = document.getElementById("toc-div");
       if (tocDiv) {


### PR DESCRIPTION
## 修改原因

使用 NexT 主题，页面加载完成后，会调用 `NexT.boot.refresh()` 方法对页面进行初始化，其中包含代码高亮、图片缩放、懒加载、外部链接处理等操作：

```javascript
NexT.boot.refresh = function() {

  /**
   * Register JS handlers by condition option.
   * Need to add config option in Front-End at 'scripts/helpers/next-config.js' file.
   */
  CONFIG.prism && window.Prism.highlightAll();
  CONFIG.fancybox && NexT.utils.wrapImageWithFancyBox();
  CONFIG.mediumzoom && window.mediumZoom('.post-body :not(a) > img, .post-body > img', {
    background: 'var(--content-bg-color)'
  });
  CONFIG.lazyload && window.lozad('.post-body img').observe();
  CONFIG.pangu && window.pangu.spacingPage();

  CONFIG.exturl && NexT.utils.registerExtURL();
  NexT.utils.registerCopyCode();
  NexT.utils.registerTabsTag();
  NexT.utils.registerActiveMenuItem();
  NexT.utils.registerLangSelect();
  NexT.utils.registerSidebarTOC();
  NexT.utils.wrapTableWithBox();
  NexT.utils.registerVideoIframe();
};
```

## 修改内容

模板 html5 lazyload 代码，在解锁完成后，通过 `window.NexT` 判断是否使用了 NexT 主题，如果使用了，则调用 `NexT.boot.refresh()` 进行初始化。