### PR TITLE
Add event when blog decrypted

### DIFF
--- a/lib/hbe.js
+++ b/lib/hbe.js
@@ -216,6 +216,10 @@ const knownPrefix = "<hbe-prefix></hbe-prefix>";
           tocDivs[idx].style.display = 'inline';
         }
       }
+      
+      // trigger event
+      var event = new Event('hexo-blog-decrypt');
+      window.dispatchEvent(event);
 
       return await verifyContent(hmacKey, decoded);
     }).catch((e) => {


### PR DESCRIPTION
# PR

Issue Fixed #

## Proposed Changes

在文章成功解密之后，抛出自定义事件，以支持主题内部监听解密状态，进行初始化页面等操作。

After successfully decrypting the article, a custom event is triggered to support internal theme listeners for initializing the page and other operations.

https://github.com/f-dong/hexo-theme-minimalism/issues/21

