### PR TITLE
docs: add GitHub Actions Tests badge to both READMEs

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -1,6 +1,7 @@
 # hexo-blog-encrypt
 
 ![GitHub release (latest SemVer including pre-releases)](https://img.shields.io/github/v/release/D0n9x1n/hexo-blog-encrypt?include_prereleases)
+[![Tests](https://github.com/D0n9X1n/hexo-blog-encrypt/actions/workflows/test.yml/badge.svg?branch=master)](https://github.com/D0n9X1n/hexo-blog-encrypt/actions/workflows/test.yml)
 [![Build Status](https://scrutinizer-ci.com/g/MikeCoder/hexo-blog-encrypt/badges/build.png?b=master)](https://scrutinizer-ci.com/g/MikeCoder/hexo-blog-encrypt/build-status/master)
 [![Scrutinizer Code Quality](https://scrutinizer-ci.com/g/MikeCoder/hexo-blog-encrypt/badges/quality-score.png?b=master)](https://scrutinizer-ci.com/g/MikeCoder/hexo-blog-encrypt/?branch=master)
 

--- a/ReadMe.zh.md
+++ b/ReadMe.zh.md
@@ -1,6 +1,7 @@
 # hexo-blog-encrypt
 
 ![GitHub release (latest SemVer including pre-releases)](https://img.shields.io/github/v/release/D0n9x1n/hexo-blog-encrypt?include_prereleases)
+[![Tests](https://github.com/D0n9X1n/hexo-blog-encrypt/actions/workflows/test.yml/badge.svg?branch=master)](https://github.com/D0n9X1n/hexo-blog-encrypt/actions/workflows/test.yml)
 [![Build Status](https://scrutinizer-ci.com/g/MikeCoder/hexo-blog-encrypt/badges/build.png?b=master)](https://scrutinizer-ci.com/g/MikeCoder/hexo-blog-encrypt/build-status/master)
 [![Scrutinizer Code Quality](https://scrutinizer-ci.com/g/MikeCoder/hexo-blog-encrypt/badges/quality-score.png?b=master)](https://scrutinizer-ci.com/g/MikeCoder/hexo-blog-encrypt/?branch=master)
 


### PR DESCRIPTION
## What

Adds the **`Tests`** GitHub Actions badge to both `ReadMe.md` and `ReadMe.zh.md`, beside the existing version badge. The CI workflow itself was added in #227 (commit `04eb227`); this PR just makes its status visible from the repo home page.

```
[![Tests](https://github.com/D0n9X1n/hexo-blog-encrypt/actions/workflows/test.yml/badge.svg?branch=master)](https://github.com/D0n9X1n/hexo-blog-encrypt/actions/workflows/test.yml)
```

The badge tracks `master`, so it always reflects the production-gated CI state.

## Verification (local, before push)

Per the new "PR-must-be-perfect-before-checkin" protocol:

- `curl -I` against the badge SVG URL → **HTTP 200**
- Clean-tree dry-run: `rm -rf node_modules tests/fixtures/hexo-site/node_modules && npm install && npm test`
  - lint clean
  - server tests: 23/23 pass, c8 coverage on `index.js` 100% stmts
  - e2e tests: 32/32 pass in 2.2s

## Scope

Docs-only. No SUT, helper, or workflow changes. README diff is two lines, identical position in each file.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
