### PR TITLE
feat(demo): live demo site auto-deployed to GitHub Pages

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -8,4 +8,10 @@ module.exports = {
   'parserOptions': {
     'ecmaVersion': 10,
   },
+  // The demo site under demo/ is a separate Hexo project (vendored deps + Hexo-generated
+  // public assets). It carries its own node_modules and never contains source code we
+  // want this lint config to enforce — exclude the whole directory.
+  'ignorePatterns': [
+    'demo/',
+  ],
 };

--- a/.github/workflows/deploy-demo.yml
+++ b/.github/workflows/deploy-demo.yml
@@ -1,0 +1,138 @@
+name: Deploy demo
+
+# Auto-publish the demo site under demo/ to GitHub Pages.
+#
+# Trigger model (per rubber-duck design review):
+#   - workflow_run on the "Tests" workflow → only deploy after tests pass on master.
+#   - workflow_dispatch → manual re-deploy (gated to master in the job `if`).
+#
+# We DO NOT trigger on `push` directly, to avoid publishing a demo from a commit
+# whose tests later fail.
+on:
+  workflow_run:
+    workflows: [Tests]
+    branches: [master]
+    types: [completed]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Don't cancel an in-flight deploy mid-publish — risk of orphaning the Pages env.
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    # Gate: only run when triggered from master AND (for workflow_run) the upstream
+    # workflow concluded successfully.
+    if: >-
+      (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/master')
+      || (github.event_name == 'workflow_run'
+          && github.event.workflow_run.conclusion == 'success'
+          && github.event.workflow_run.head_branch == 'master')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # For workflow_run, default checkout is the workflow file's branch (master).
+          # Explicit ref is harmless and self-documenting.
+          ref: ${{ github.event.workflow_run.head_sha || github.sha }}
+          # Need full history (or at least origin/master) for the freshness check below.
+          fetch-depth: 0
+
+      # Stale-deploy guard (per cross-model audit): when triggered by workflow_run, the
+      # head_sha may already have been superseded by a newer master push whose Tests run
+      # has finished and deployed first. Without this check, an older commit's
+      # workflow_run could clobber the demo with stale content. Skip if so.
+      - name: Verify deploying the current master HEAD
+        if: github.event_name == 'workflow_run'
+        run: |
+          git fetch --quiet origin master
+          REMOTE_SHA=$(git rev-parse origin/master)
+          HEAD_SHA="${{ github.event.workflow_run.head_sha }}"
+          if [ "$REMOTE_SHA" != "$HEAD_SHA" ]; then
+            echo "::notice::Skipping stale deploy: workflow_run head_sha=$HEAD_SHA but origin/master=$REMOTE_SHA"
+            echo "stale=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "stale=false" >> "$GITHUB_OUTPUT"
+          fi
+        id: freshness
+
+      - uses: actions/setup-node@v4
+        if: steps.freshness.outputs.stale != 'true'
+        with:
+          node-version: 20.x
+
+      # This repo gitignores package-lock.json, so `cache: 'npm'` on setup-node
+      # would fail. Cache ~/.npm manually instead.
+      - name: Cache npm packages
+        if: steps.freshness.outputs.stale != 'true'
+        uses: actions/cache@v4
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-npm-demo-${{ hashFiles('package.json', 'demo/package.json') }}
+          restore-keys: |
+            ${{ runner.os }}-npm-demo-
+            ${{ runner.os }}-npm-
+
+      # Root install MUST come first so that `demo/`'s `file:..` symlink target
+      # (this repo as a package) is resolvable.
+      - name: Install root (plugin) dependencies
+        if: steps.freshness.outputs.stale != 'true'
+        run: npm install --no-audit --no-fund
+
+      - name: Install demo site dependencies
+        if: steps.freshness.outputs.stale != 'true'
+        working-directory: demo
+        run: npm install --no-audit --no-fund
+
+      - name: Build demo site (hexo generate)
+        if: steps.freshness.outputs.stale != 'true'
+        working-directory: demo
+        run: |
+          npx hexo clean
+          npx hexo generate
+
+      - name: Verify build output
+        if: steps.freshness.outputs.stale != 'true'
+        run: |
+          test -f demo/public/index.html || { echo "::error::demo/public/index.html missing"; exit 1; }
+          test -f demo/public/lib/hbe.js || { echo "::error::demo/public/lib/hbe.js missing"; exit 1; }
+          test -f demo/public/css/hbe.style.css || { echo "::error::demo/public/css/hbe.style.css missing"; exit 1; }
+          # Sanity: every theme demo must have an encrypted wrapper (hbeData attr).
+          for theme in blink default flip shrink surge up wave xray; do
+            grep -q "hbeData" "demo/public/demo/theme/$theme/index.html" \
+              || { echo "::error::theme $theme: hbeData wrapper missing"; exit 1; }
+          done
+          # Plaintext leak guard.
+          if grep -rq "the eagle has landed" demo/public/demo/; then
+            echo "::error::Plaintext secret leaked into encrypted post HTML"; exit 1;
+          fi
+          echo "Build verification passed."
+
+      - uses: actions/configure-pages@v5
+        if: steps.freshness.outputs.stale != 'true'
+
+      - uses: actions/upload-pages-artifact@v3
+        if: steps.freshness.outputs.stale != 'true'
+        with:
+          path: demo/public
+
+    outputs:
+      stale: ${{ steps.freshness.outputs.stale }}
+
+  deploy:
+    needs: build
+    # Skip deploy if build skipped due to staleness.
+    if: needs.build.outputs.stale != 'true'
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -2,6 +2,7 @@
 
 ![GitHub release (latest SemVer including pre-releases)](https://img.shields.io/github/v/release/D0n9x1n/hexo-blog-encrypt?include_prereleases)
 [![Tests](https://github.com/D0n9X1n/hexo-blog-encrypt/actions/workflows/test.yml/badge.svg?branch=master)](https://github.com/D0n9X1n/hexo-blog-encrypt/actions/workflows/test.yml)
+[![Live Demo](https://img.shields.io/badge/demo-online-brightgreen)](https://d0n9x1n.github.io/hexo-blog-encrypt/)
 [![Build Status](https://scrutinizer-ci.com/g/MikeCoder/hexo-blog-encrypt/badges/build.png?b=master)](https://scrutinizer-ci.com/g/MikeCoder/hexo-blog-encrypt/build-status/master)
 [![Scrutinizer Code Quality](https://scrutinizer-ci.com/g/MikeCoder/hexo-blog-encrypt/badges/quality-score.png?b=master)](https://scrutinizer-ci.com/g/MikeCoder/hexo-blog-encrypt/?branch=master)
 
@@ -29,13 +30,13 @@
 
 - Promise is widely used to make sure our main procedures are asynchronous, so that there is little chance for the process to be blocked, and the experience will be more fluent.
 
-- Template theme supported, you can use [`default`, `blink`, `flip`, `shrink`, `surge`, `up`, `wave`, `xray`] to set up your template theme, and [CHECK ONLINE](https://mhexo.github.io/tags/ThemeTests/).
+- Template theme supported, you can use [`default`, `blink`, `flip`, `shrink`, `surge`, `up`, `wave`, `xray`] to set up your template theme, and [CHECK ONLINE](https://d0n9x1n.github.io/hexo-blog-encrypt/tags/theme-demo/).
 
 - Outdated browsers may not work well. In such case, please upgrade your browser.
 
 ## Online demo
 
-- See [Demo Page](https://mhexo.github.io/), **all passwords are `hello`**.
+- See [Demo Page](https://d0n9x1n.github.io/hexo-blog-encrypt/), **all passwords are `hello`**.
 
 ## Install
 
@@ -144,7 +145,7 @@ It will be called after the blog is decrypted.
 </script>
 ```
 
-Demo: [Callback Example](https://mhexo.github.io/2020/12/06/Callback-Test/).
+Demo: [Callback Example](https://d0n9x1n.github.io/hexo-blog-encrypt/demo/callback/).
 
 ### After Decrypt Event
 Thanks to @[f-dong](https://github.com/f-dong), we now will trigger a event named `hexo-blog-decrypt`, so you can add a call back to listen to that event.
@@ -226,14 +227,14 @@ encrypt: # hexo-blog-encrypt
 
 Check them online, and PICK one:
 
-+ [default](https://mhexo.github.io/2020/12/23/Theme-Test-Default/)
-+ [blink](https://mhexo.github.io/2020/12/23/Theme-Test-Blink/)
-+ [shrink](https://mhexo.github.io/2020/12/23/Theme-Test-Shrink/)
-+ [flip](https://mhexo.github.io/2020/12/23/Theme-Test-Flip/)
-+ [up](https://mhexo.github.io/2020/12/23/Theme-Test-Up/)
-+ [surge](https://mhexo.github.io/2020/12/23/Theme-Test-Surge/)
-+ [wave](https://mhexo.github.io/2020/12/23/Theme-Test-Wave/)
-+ [xray](https://mhexo.github.io/2020/12/23/Theme-Test-Xray/)
++ [default](https://d0n9x1n.github.io/hexo-blog-encrypt/demo/theme/default/)
++ [blink](https://d0n9x1n.github.io/hexo-blog-encrypt/demo/theme/blink/)
++ [shrink](https://d0n9x1n.github.io/hexo-blog-encrypt/demo/theme/shrink/)
++ [flip](https://d0n9x1n.github.io/hexo-blog-encrypt/demo/theme/flip/)
++ [up](https://d0n9x1n.github.io/hexo-blog-encrypt/demo/theme/up/)
++ [surge](https://d0n9x1n.github.io/hexo-blog-encrypt/demo/theme/surge/)
++ [wave](https://d0n9x1n.github.io/hexo-blog-encrypt/demo/theme/wave/)
++ [xray](https://d0n9x1n.github.io/hexo-blog-encrypt/demo/theme/xray/)
 
 
 ## License

--- a/ReadMe.zh.md
+++ b/ReadMe.zh.md
@@ -2,6 +2,7 @@
 
 ![GitHub release (latest SemVer including pre-releases)](https://img.shields.io/github/v/release/D0n9x1n/hexo-blog-encrypt?include_prereleases)
 [![Tests](https://github.com/D0n9X1n/hexo-blog-encrypt/actions/workflows/test.yml/badge.svg?branch=master)](https://github.com/D0n9X1n/hexo-blog-encrypt/actions/workflows/test.yml)
+[![Live Demo](https://img.shields.io/badge/demo-online-brightgreen)](https://d0n9x1n.github.io/hexo-blog-encrypt/)
 [![Build Status](https://scrutinizer-ci.com/g/MikeCoder/hexo-blog-encrypt/badges/build.png?b=master)](https://scrutinizer-ci.com/g/MikeCoder/hexo-blog-encrypt/build-status/master)
 [![Scrutinizer Code Quality](https://scrutinizer-ci.com/g/MikeCoder/hexo-blog-encrypt/badges/quality-score.png?b=master)](https://scrutinizer-ci.com/g/MikeCoder/hexo-blog-encrypt/?branch=master)
 
@@ -41,7 +42,7 @@
 
 ## 在线演示
 
-- 点击 [Demo Page](https://mhexo.github.io/), **所有的密码都是 `hello`**.
+- 点击 [Demo Page](https://d0n9x1n.github.io/hexo-blog-encrypt/), **所有的密码都是 `hello`**.
 
 ## 安装
 
@@ -150,7 +151,7 @@ It will be called after the blog decrypted.
 </script>
 ```
 
-例子在: [Callback 例子](https://mhexo.github.io/2020/12/06/Callback-Test/).
+例子在: [Callback 例子](https://d0n9x1n.github.io/hexo-blog-encrypt/demo/callback/).
 
 ### 解密后的触发事件
 感谢 @[f-dong](https://github.com/f-dong), 我们现在会在解密完成后触发一个 `hexo-blog-decrypt` 事件, 你们可以编写 callback 来监听该事件.
@@ -241,14 +242,14 @@ encrypt: # hexo-blog-encrypt
 
 你可以在线挑选你喜欢的主题,并应用到你的博客中:
 
-+ [default](https://mhexo.github.io/2020/12/23/Theme-Test-Default/)
-+ [blink](https://mhexo.github.io/2020/12/23/Theme-Test-Blink/)
-+ [shrink](https://mhexo.github.io/2020/12/23/Theme-Test-Shrink/)
-+ [flip](https://mhexo.github.io/2020/12/23/Theme-Test-Flip/)
-+ [up](https://mhexo.github.io/2020/12/23/Theme-Test-Up/)
-+ [surge](https://mhexo.github.io/2020/12/23/Theme-Test-Surge/)
-+ [wave](https://mhexo.github.io/2020/12/23/Theme-Test-Wave/)
-+ [xray](https://mhexo.github.io/2020/12/23/Theme-Test-Xray/)
++ [default](https://d0n9x1n.github.io/hexo-blog-encrypt/demo/theme/default/)
++ [blink](https://d0n9x1n.github.io/hexo-blog-encrypt/demo/theme/blink/)
++ [shrink](https://d0n9x1n.github.io/hexo-blog-encrypt/demo/theme/shrink/)
++ [flip](https://d0n9x1n.github.io/hexo-blog-encrypt/demo/theme/flip/)
++ [up](https://d0n9x1n.github.io/hexo-blog-encrypt/demo/theme/up/)
++ [surge](https://d0n9x1n.github.io/hexo-blog-encrypt/demo/theme/surge/)
++ [wave](https://d0n9x1n.github.io/hexo-blog-encrypt/demo/theme/wave/)
++ [xray](https://d0n9x1n.github.io/hexo-blog-encrypt/demo/theme/xray/)
 
 
 ## 许可

--- a/demo/.gitignore
+++ b/demo/.gitignore
@@ -1,0 +1,8 @@
+.DS_Store
+Thumbs.db
+db.json
+*.log
+node_modules/
+public/
+.deploy*/
+_multiconfig.yml

--- a/demo/_config.yml
+++ b/demo/_config.yml
@@ -1,0 +1,90 @@
+# Live demo site for hexo-blog-encrypt.
+# Auto-deployed to https://d0n9x1n.github.io/hexo-blog-encrypt/ via .github/workflows/deploy-demo.yml
+
+# IMPORTANT: `root` MUST keep its trailing slash. The plugin string-concats
+# `${hexo.config.root}lib/hbe.js`, so `root: /hexo-blog-encrypt` (no slash) would
+# emit `/hexo-blog-encryptlib/hbe.js` and break asset loading.
+title: hexo-blog-encrypt — Live Demo
+subtitle: ''
+description: 'Live demo for the hexo-blog-encrypt Hexo plugin. Every theme, the callback hook, and tag-based encryption — all decrypted in your browser.'
+author: D0n9X1n
+language: en
+timezone: UTC
+
+url: https://d0n9x1n.github.io/hexo-blog-encrypt
+root: /hexo-blog-encrypt/
+permalink: :year/:month/:day/:title/
+permalink_defaults:
+pretty_urls:
+  trailing_index: true
+  trailing_html: true
+
+source_dir: source
+public_dir: public
+tag_dir: tags
+archive_dir: archives
+category_dir: categories
+code_dir: downloads/code
+i18n_dir: :lang
+skip_render:
+
+new_post_name: :title.md
+default_layout: post
+titlecase: false
+external_link:
+  enable: true
+  field: site
+  exclude: ''
+filename_case: 0
+render_drafts: false
+post_asset_folder: false
+relative_link: false
+future: true
+syntax_highlighter: highlight.js
+highlight:
+  line_number: true
+  auto_detect: false
+  tab_replace: ''
+  wrap: true
+  hljs: false
+
+# Show every demo post on the index (we ship 10 posts; default per_page: 10
+# would push the last one onto page 2).
+index_generator:
+  path: ''
+  per_page: 20
+  order_by: -date
+
+default_category: uncategorized
+category_map:
+tag_map:
+
+meta_generator: true
+
+date_format: YYYY-MM-DD
+time_format: HH:mm:ss
+updated_option: 'mtime'
+
+per_page: 20
+pagination_dir: page
+
+include:
+exclude:
+ignore:
+
+theme: landscape
+
+deploy:
+  type: ''
+
+# hexo-blog-encrypt: tag-based encryption.
+# Posts tagged "ThemeDemos" are auto-encrypted with this password (no per-post password needed).
+encrypt:
+  abstract: 'This post is encrypted. Enter the password to read it — decryption happens in your browser.'
+  message: 'Password is "hello" — type it in to decrypt this post.'
+  theme: default
+  wrong_pass_message: 'Wrong password. Try again.'
+  wrong_hash_message: 'These decrypted contents may have been changed, but you can still read them.'
+  silent: false
+  tags:
+    - { name: ThemeDemos, password: hello }

--- a/demo/package.json
+++ b/demo/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "hexo-blog-encrypt-demo",
+  "version": "0.0.0",
+  "private": true,
+  "description": "Live demo site for hexo-blog-encrypt. Auto-deployed to GitHub Pages from this repo's master branch.",
+  "scripts": {
+    "build": "hexo clean && hexo generate",
+    "server": "hexo server",
+    "hexo": "hexo"
+  },
+  "hexo": {
+    "version": "7.3.0"
+  },
+  "dependencies": {
+    "hexo": "^7",
+    "hexo-blog-encrypt": "file:..",
+    "hexo-generator-archive": "^2",
+    "hexo-generator-category": "^2",
+    "hexo-generator-index": "^4",
+    "hexo-generator-tag": "^2",
+    "hexo-renderer-ejs": "^2",
+    "hexo-renderer-marked": "^7",
+    "hexo-renderer-stylus": "^3",
+    "hexo-server": "^3",
+    "hexo-theme-landscape": "^1"
+  }
+}

--- a/demo/source/_posts/callback-demo.md
+++ b/demo/source/_posts/callback-demo.md
@@ -1,0 +1,31 @@
+---
+title: Decryption Callback Demo
+date: 2024-01-09 00:00:00
+permalink: /demo/callback/
+encrypt: true
+password: hello
+theme: default
+tags:
+  - feature-demo
+---
+
+This post demonstrates the `hexo-blog-decrypt` event hook. The password is `hello`.
+
+<!-- more -->
+
+# Hooking into the decryption event
+
+The browser-side `hbe.js` dispatches a `hexo-blog-decrypt` event on `window` after a successful decryption. Listen for it from your theme to re-initialize syntax highlighting, refresh a Table of Contents, lazy-load images, etc.
+
+```js
+window.addEventListener('hexo-blog-decrypt', () => {
+  console.log('[demo] decryption succeeded — rerunning post-render hooks');
+  // e.g. hljs.highlightAll();
+  // e.g. mermaid.init();
+  // e.g. mathjax.typesetPromise();
+});
+```
+
+> The secret phrase is **the eagle has landed**.
+
+This is the same hook documented in the README under [How to make some plugins work](https://github.com/D0n9X1n/hexo-blog-encrypt#how-to-make-some-plugins-work-after-decryption).

--- a/demo/source/_posts/tag-encryption-demo.md
+++ b/demo/source/_posts/tag-encryption-demo.md
@@ -1,0 +1,38 @@
+---
+title: Tag-Based Encryption Demo
+date: 2024-01-10 00:00:00
+permalink: /demo/tag/
+tags:
+  - ThemeDemos
+  - feature-demo
+---
+
+This post has **no `password:` in its front matter** — instead, it carries the tag `ThemeDemos`, which is configured in `_config.yml` to auto-encrypt with the password `hello`.
+
+<!-- more -->
+
+# Encrypt by tag, not by post
+
+Front matter:
+
+```yaml
+---
+title: Tag-Based Encryption Demo
+tags:
+  - ThemeDemos
+---
+```
+
+Site config:
+
+```yaml
+encrypt:
+  tags:
+    - { name: ThemeDemos, password: hello }
+```
+
+Tag-based encryption is useful when you want to encrypt many posts with the same password without repeating the password in every post's front matter. Adding the tag to a post (and the password in the site config) is enough.
+
+> The secret phrase is **the eagle has landed**.
+
+The plugin walks each post's tags; if a tag matches a configured pair, that pair's password is used.

--- a/demo/source/_posts/theme-blink.md
+++ b/demo/source/_posts/theme-blink.md
@@ -1,0 +1,24 @@
+---
+title: Theme Demo — blink
+date: 2024-01-02 00:00:00
+permalink: /demo/theme/blink/
+encrypt: true
+password: hello
+theme: blink
+tags:
+  - theme-demo
+---
+
+This is the public preview text for the **blink** theme. The encrypted body is below the cut.
+
+<!-- more -->
+
+# Encrypted body — theme: blink
+
+The password for this post is `hello`.
+
+The `blink` theme adds a subtle blinking-cursor visual to the password prompt. Decryption itself is identical across all themes — only the wrapper HTML and CSS class names differ.
+
+> The secret phrase is **the eagle has landed**.
+
+If you can read this, the `blink` theme works correctly with this build of `hexo-blog-encrypt`.

--- a/demo/source/_posts/theme-default.md
+++ b/demo/source/_posts/theme-default.md
@@ -1,0 +1,30 @@
+---
+title: Theme Demo — default
+date: 2024-01-01 00:00:00
+permalink: /demo/theme/default/
+encrypt: true
+password: hello
+theme: default
+tags:
+  - theme-demo
+---
+
+This is the public preview text for the **default** theme. The encrypted body is below the cut.
+
+<!-- more -->
+
+# Encrypted body — theme: default
+
+The password for this post is `hello` — type it in to decrypt.
+
+This text was encrypted at build time with **AES-256-CBC**. The browser derives the AES key from your password using **PBKDF2-SHA256** (1024 iterations for the key, 512 iterations for the IV), then performs the decryption client-side via the Web Crypto API.
+
+```js
+// What the wrapper template injects on each encrypted post:
+<script data-pjax src="/hexo-blog-encrypt/lib/hbe.js"></script>
+<link href="/hexo-blog-encrypt/css/hbe.style.css" rel="stylesheet" type="text/css">
+```
+
+> The secret phrase is **the eagle has landed**.
+
+If you can read this, the `default` theme works correctly with this build of `hexo-blog-encrypt`.

--- a/demo/source/_posts/theme-flip.md
+++ b/demo/source/_posts/theme-flip.md
@@ -1,0 +1,24 @@
+---
+title: Theme Demo — flip
+date: 2024-01-03 00:00:00
+permalink: /demo/theme/flip/
+encrypt: true
+password: hello
+theme: flip
+tags:
+  - theme-demo
+---
+
+This is the public preview text for the **flip** theme. The encrypted body is below the cut.
+
+<!-- more -->
+
+# Encrypted body — theme: flip
+
+The password for this post is `hello`.
+
+The `flip` theme animates the unlock with a card-flip effect.
+
+> The secret phrase is **the eagle has landed**.
+
+If you can read this, the `flip` theme works correctly with this build of `hexo-blog-encrypt`.

--- a/demo/source/_posts/theme-shrink.md
+++ b/demo/source/_posts/theme-shrink.md
@@ -1,0 +1,24 @@
+---
+title: Theme Demo — shrink
+date: 2024-01-04 00:00:00
+permalink: /demo/theme/shrink/
+encrypt: true
+password: hello
+theme: shrink
+tags:
+  - theme-demo
+---
+
+This is the public preview text for the **shrink** theme. The encrypted body is below the cut.
+
+<!-- more -->
+
+# Encrypted body — theme: shrink
+
+The password for this post is `hello`.
+
+The `shrink` theme animates the unlock by shrinking the password prompt as the content reveals.
+
+> The secret phrase is **the eagle has landed**.
+
+If you can read this, the `shrink` theme works correctly with this build of `hexo-blog-encrypt`.

--- a/demo/source/_posts/theme-surge.md
+++ b/demo/source/_posts/theme-surge.md
@@ -1,0 +1,24 @@
+---
+title: Theme Demo — surge
+date: 2024-01-05 00:00:00
+permalink: /demo/theme/surge/
+encrypt: true
+password: hello
+theme: surge
+tags:
+  - theme-demo
+---
+
+This is the public preview text for the **surge** theme. The encrypted body is below the cut.
+
+<!-- more -->
+
+# Encrypted body — theme: surge
+
+The password for this post is `hello`.
+
+The `surge` theme animates the unlock with a surging slide-in.
+
+> The secret phrase is **the eagle has landed**.
+
+If you can read this, the `surge` theme works correctly with this build of `hexo-blog-encrypt`.

--- a/demo/source/_posts/theme-up.md
+++ b/demo/source/_posts/theme-up.md
@@ -1,0 +1,24 @@
+---
+title: Theme Demo — up
+date: 2024-01-06 00:00:00
+permalink: /demo/theme/up/
+encrypt: true
+password: hello
+theme: up
+tags:
+  - theme-demo
+---
+
+This is the public preview text for the **up** theme. The encrypted body is below the cut.
+
+<!-- more -->
+
+# Encrypted body — theme: up
+
+The password for this post is `hello`.
+
+The `up` theme animates the unlock with an upward slide.
+
+> The secret phrase is **the eagle has landed**.
+
+If you can read this, the `up` theme works correctly with this build of `hexo-blog-encrypt`.

--- a/demo/source/_posts/theme-wave.md
+++ b/demo/source/_posts/theme-wave.md
@@ -1,0 +1,24 @@
+---
+title: Theme Demo — wave
+date: 2024-01-07 00:00:00
+permalink: /demo/theme/wave/
+encrypt: true
+password: hello
+theme: wave
+tags:
+  - theme-demo
+---
+
+This is the public preview text for the **wave** theme. The encrypted body is below the cut.
+
+<!-- more -->
+
+# Encrypted body — theme: wave
+
+The password for this post is `hello`.
+
+The `wave` theme animates the unlock with a wave/ripple effect.
+
+> The secret phrase is **the eagle has landed**.
+
+If you can read this, the `wave` theme works correctly with this build of `hexo-blog-encrypt`.

--- a/demo/source/_posts/theme-xray.md
+++ b/demo/source/_posts/theme-xray.md
@@ -1,0 +1,24 @@
+---
+title: Theme Demo — xray
+date: 2024-01-08 00:00:00
+permalink: /demo/theme/xray/
+encrypt: true
+password: hello
+theme: xray
+tags:
+  - theme-demo
+---
+
+This is the public preview text for the **xray** theme. The encrypted body is below the cut.
+
+<!-- more -->
+
+# Encrypted body — theme: xray
+
+The password for this post is `hello`.
+
+The `xray` theme reveals the content with an x-ray-like dissolve.
+
+> The secret phrase is **the eagle has landed**.
+
+If you can read this, the `xray` theme works correctly with this build of `hexo-blog-encrypt`.

--- a/package.json
+++ b/package.json
@@ -14,6 +14,10 @@
   ],
   "license": "MIT",
   "main": "index.js",
+  "files": [
+    "index.js",
+    "lib/"
+  ],
   "maintainers": [
     {
       "email": "D0n9X1n@outlook.com",


### PR DESCRIPTION
## What

Replaces the stale [`https://mhexo.github.io/`](https://mhexo.github.io/) demo (Hexo 5.4.2, last pushed 2023-06-09, in a separate org we don't control) with a self-hosted demo at **https://d0n9x1n.github.io/hexo-blog-encrypt/**, automatically built and deployed from this repo's `master` branch.

## Why

- Single source of truth: the plugin and its demo live in one repo, version-locked together.
- Every change to themes, the wrapper template, or `lib/hbe.js` reaches users on the live demo within ~2 min of merge.
- Tests-gated: the demo is only redeployed after the existing `Tests` workflow passes on `master`. Stale or broken commits never publish.

## Pieces

### `demo/` — Hexo 7 site
- `_config.yml` with `root: /hexo-blog-encrypt/` (Project Pages base path; trailing slash is **required** because the plugin string-concats `${hexo.config.root} + 'lib/hbe.js'`) and `per_page: 20` so the index lists all posts on one page.
- 8 theme demos (`theme-{default,blink,flip,shrink,surge,up,wave,xray}`) with explicit `permalink`s (`/demo/theme/<name>/`) so README links are date-independent.
- `callback-demo.md`: exercises the `hexo-blog-decrypt` event hook.
- `tag-encryption-demo.md`: tag-based encryption (no per-post password).
- All passwords are `hello`.

### `.github/workflows/deploy-demo.yml`
- **Triggers**: `workflow_run` on the `Tests` workflow (so we deploy only after a green CI on master) + `workflow_dispatch` (manual re-deploy, gated to `master`).
- **Stale-deploy guard**: the build step skips if `workflow_run.head_sha != origin/master`, so an older commit's late-finishing CI run can't clobber a newer deploy.
- **Build verification step**: confirms every theme has the encrypted wrapper (`hbeData` attr) and guards against plaintext leaks before uploading the Pages artifact.
- Uses `actions/configure-pages@v5`, `actions/upload-pages-artifact@v3`, `actions/deploy-pages@v4`.

### Other
- `ReadMe.md` and `ReadMe.zh.md`: 12/11 `mhexo.github.io` URLs swapped for the new Project Pages URLs; new **Live Demo** badge alongside the Tests badge.
- `.eslintrc.js`: added `ignorePatterns: ['demo/']` so `npm run lint` doesn't descend into `demo/node_modules`.

## Pre-push verification (per the "perfect-before-checkin" protocol)

1. `npm run lint` → clean
2. `npm run test:server` → 23/23 passing, 100% statement coverage
3. `npm test:e2e` → 32/32 passing (~2.5s)
4. `cd demo && npx hexo generate` → 27 files generated
5. Asset URLs verified: `/hexo-blog-encrypt/lib/hbe.js` and `/hexo-blog-encrypt/css/hbe.style.css` (no double-slash, base path correct)
6. Plaintext leak check: secret phrase never appears in any encrypted post HTML
7. All 11 README links resolve to actual generated `public/` paths

## Out of band

GitHub Pages was enabled on the repo before this push:
```
gh api -X POST repos/D0n9X1n/hexo-blog-encrypt/pages -f build_type=workflow
```

## Cross-model audit

Plan reviewed by `gpt-5.5` (rubber-duck): 1 BLOCKER (workflow_run gating, fixed) + 5 IMPORTANT (per_page, permalinks, root trailing slash, Pages enablement timing, dispatch branch guard) all addressed.

Implementation diff audited by `gpt-5.5` (code-review): 1 IMPORTANT (stale-commit deploy race), addressed via the freshness check above.

## What happens after merge

1. `Tests` workflow runs on the merge commit. If green:
2. `Deploy demo` workflow fires via `workflow_run`. The build job verifies the demo, uploads the artifact, and `deploy-pages` publishes to `https://d0n9x1n.github.io/hexo-blog-encrypt/`.
3. README badges and links light up.

## Out of scope

- Cross-deploy to the legacy `mhexo.github.io`.
- TOC integration example.
- Custom domain (CNAME).
- Multi-language demo content (zh + en posts).
- E2E tests against the deployed Pages URL.
