### PR TITLE
Feat/stable salt

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -185,11 +185,23 @@ encrypt: # hexo-blog-encrypt
     show: true
     text: Decrypt
 
-  # Cache the decrypted plaintext in localStorage so reloads skip the
-  # password prompt. OFF by default — opt in per post via front-matter
+  # Cache the derived AES key in localStorage so reloads skip the password
+  # prompt. OFF by default — opt in per post via front-matter
   # `autoSave: true`, or globally here. Cache key is namespaced under
   # `hbe.v4.<post-permalink-hash>`.
   autoSave: false
+
+  # Keep the PBKDF2 salt stable across clean static builds for the same
+  # post permalink. Default: false. This is useful with autoSave on
+  # Cloudflare Pages, Vercel, Netlify, GitHub Actions, and similar
+  # platforms that rebuild generated HTML from a clean environment on
+  # every deploy.
+  #
+  # Only the salt is stable. The AES-GCM nonce remains random for every
+  # encryption to avoid nonce reuse. If the post permalink changes, the
+  # stable salt changes too, and existing localStorage cache for that page
+  # is invalidated.
+  stableSalt: false
 
   # PBKDF2 iteration count. Floor: 100_000. Recommended ≥ 600_000
   # (OWASP 2023 for PBKDF2-SHA256). Lower-than-recommended values log a
@@ -198,6 +210,12 @@ encrypt: # hexo-blog-encrypt
     iterations: 250000
 
 ```
+
+When `autoSave` reads a cached key, it compares the cached salt with the
+current page salt. A nonce change alone does not delete the cache up
+front; the browser tries the cached key with the current page nonce and
+ciphertext. If AES-GCM authentication fails, the cache entry is cleared
+and the visitor is asked for the password again.
 
 #### To disable tag encryption
 

--- a/ReadMe.zh.md
+++ b/ReadMe.zh.md
@@ -179,10 +179,20 @@ encrypt: # hexo-blog-encrypt
     show: true
     text: 解密
 
-  # 解密后是否将明文缓存到 localStorage, 让刷新页面跳过密码输入.
+  # 是否将派生出的 AES 密钥缓存到 localStorage, 让刷新页面跳过密码输入.
   # 默认 OFF — 可在文章 front-matter 中通过 `autoSave: true` 单独开启,
   # 也可以在这里全局开启. 缓存键命名空间为 `hbe.v4.<post-permalink-hash>`.
   autoSave: false
+
+  # 让同一篇文章的 PBKDF2 salt 在 clean build 间保持稳定, 文章身份来自
+  # 当前实现中的 post permalink. 默认: false. 配合 autoSave 时, 适用于
+  # Cloudflare Pages、Vercel、Netlify、GitHub Actions 等每次部署都会从
+  # 干净环境重新生成 HTML 的静态部署平台.
+  #
+  # 只稳定 salt; AES-GCM nonce 每次加密仍然随机, 避免 nonce reuse.
+  # 如果文章 permalink 改变, stable salt 也会改变, 该页面已有的
+  # localStorage 缓存会失效.
+  stableSalt: false
 
   # PBKDF2 迭代次数. 下限: 100_000. 推荐 ≥ 600_000
   # (OWASP 2023 关于 PBKDF2-SHA256 的推荐). 低于推荐值时构建会打印 warning.
@@ -191,6 +201,10 @@ encrypt: # hexo-blog-encrypt
     iterations: 250000
 
 ```
+
+`autoSave` 读取缓存密钥时会比较缓存中的 salt 与当前页面 salt. 仅 nonce
+变化不会提前删除缓存; 浏览器会使用缓存密钥配合当前页面的 nonce 与密文尝试
+解密. 如果 AES-GCM 认证失败, 该缓存条目会被清除, 访客需要重新输入密码.
 
 #### 对博文禁用 Tag 加密
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -27,7 +27,7 @@ browser bundle is built with esbuild (no runtime bundler).
 | --- | --- |
 | `index.js` | Composition root — wires config + crypto + template + generator into the Hexo filter callback. |
 | `config.js` | Deep-merge of `hexo.config.encrypt` with per-post front-matter; KDF-iterations floor; `wrong_hash_message` → `wrong_pass_message` defaulting; tag-registry lookup. |
-| `crypto.js` | PBKDF2-SHA256 → AES-256-GCM. Per-post 16-byte salt + 12-byte nonce. Returns `{ ciphertextHex, saltHex, nonceHex, tagHex, kdfIterations }`. |
+| `crypto.js` | PBKDF2-SHA256 → AES-256-GCM. Per-post 32-byte salt + 12-byte nonce. With `stableSalt: true`, the salt is derived from the post permalink; the nonce is still random for every encryption. |
 | `template.js` | Single allowlist of 11 `{{hbe…}}` placeholders + per-placeholder render mode (attr-escape / text-escape / hex-validated). The contract every theme HTML satisfies. |
 | `generator.js` | Hexo asset generator. Emits `lib/hbe.style.css` + content-hashed `lib/hbe.<hex10>.js`. The hex10 is `sha256(bundle).slice(0, 10)`. |
 | `logger.js` | Tiny console wrapper — namespaced "[hexo-blog-encrypt]" prefix + verbosity gate. |
@@ -53,6 +53,19 @@ exact attribute / placeholder table is in [`docs/THEMES.md`](THEMES.md);
 the bundle gates on `data-hbe-format="4"` and refuses to attempt
 decryption against any other value, so changing the wire format requires
 bumping the version byte and the bundle in lockstep.
+
+`stableSalt` is server-side only and does not add an eighth `data-*`
+attribute. When enabled, `src/server/index.js` derives the 32-byte salt
+from the namespace `hexo-blog-encrypt:v4:stableSalt:` plus the post
+permalink. If the permalink changes, the stable salt changes and any
+existing `autoSave` cache for that page is invalidated.
+
+For `autoSave`, the browser cache entry keeps `{ version, dk, salt,
+nonce }` for v4 schema compatibility. On load, the browser clears the
+entry when the cached salt differs from the current `data-salt`. It does
+not clear solely because the cached nonce differs; decryption always uses
+the current page's `data-nonce` and ciphertext. If AES-GCM authentication
+fails, the cache is cleared and the password form remains visible.
 
 ## Code conventions
 

--- a/docs/THEMES.md
+++ b/docs/THEMES.md
@@ -67,6 +67,12 @@ The seven `data-*` attributes the browser bundle reads from the
 | `data-kdf-iterations`  | `{{hbeKdfIterations}}`      | PBKDF2 iteration count.                             |
 | `data-auto-save`       | `{{hbeAutoSave}}`           | Whether the derived key is persisted to `localStorage`. |
 
+The `stableSalt` option deliberately does not add a `data-*` attribute.
+It only changes how the server chooses `{{hbeSalt}}` when rendering the
+page. The browser uses `data-salt` to validate cached `autoSave` keys,
+then always decrypts with the current page's `data-nonce` and
+ciphertext. If AES-GCM authentication fails, the cache is cleared.
+
 ## Forbidden
 
 To keep the one-file-drop contract intact:

--- a/src/browser/main.js
+++ b/src/browser/main.js
@@ -57,7 +57,6 @@ async function tryAutoDecrypt(mainElement, wire, guardedReveal) {
   const cachedKey = await storage.load({
     pageKey: pageKey(),
     expectedSaltHex: wire.saltHex,
-    expectedNonceHex: wire.nonceHex,
   });
   if (!cachedKey) return false;
   const result = await cryptoMod.tryDecryptWithKey({

--- a/src/browser/storage.js
+++ b/src/browser/storage.js
@@ -9,7 +9,7 @@
 //     version: 4,
 //     dk:      base64(rawKeyBytes),  // 32 bytes
 //     salt:    <hex64>,              // matches data-salt
-//     nonce:   <hex24>,              // matches data-nonce
+//     nonce:   <hex24>,              // retained for v4 schema compatibility
 //   }
 //
 // IMPORTANT: when `autoSave` is false, save() is a no-op. When reading, any
@@ -54,7 +54,7 @@ async function save({ pageKey, key, saltHex, nonceHex, autoSave }) {
   }
 }
 
-async function load({ pageKey, expectedSaltHex, expectedNonceHex }) {
+async function load({ pageKey, expectedSaltHex }) {
   let entry;
   try {
     const raw = localStorage.getItem(storageKey(pageKey));
@@ -78,9 +78,10 @@ async function load({ pageKey, expectedSaltHex, expectedNonceHex }) {
     return null;
   }
 
-  // If the encrypted page's salt/nonce changed (rebuild minted fresh ones),
-  // the cached key is stale. Drop it.
-  if (entry.salt !== expectedSaltHex || entry.nonce !== expectedNonceHex) {
+  // If the encrypted page's salt changed, the cached key is stale. Nonce is
+  // not part of PBKDF2 key derivation; decrypt still uses the current page's
+  // nonce and ciphertext, and failure clears the cache in main.js.
+  if (entry.salt !== expectedSaltHex) {
     try { localStorage.removeItem(storageKey(pageKey)); } catch (_e) { /* ignore */ }
     return null;
   }

--- a/src/server/config.js
+++ b/src/server/config.js
@@ -13,6 +13,7 @@ const DEFAULTS = Object.freeze({
   // unified GCM failure handling).
   silent: false,
   autoSave: false,
+  stableSalt: false,
   decryptButton: Object.freeze({
     show: true,
     text: 'Decrypt',
@@ -70,6 +71,7 @@ const POST_KNOWN_KEYS = [
   'wrong_hash_message',
   'silent',
   'autoSave',
+  'stableSalt',
   'decryptButton',
   'kdf',
 ];

--- a/src/server/crypto.js
+++ b/src/server/crypto.js
@@ -21,7 +21,15 @@ function encrypt(plaintext, password, opts) {
   const iterations = (opts && Number.isInteger(opts.iterations) && opts.iterations > 0)
     ? opts.iterations
     : DEFAULT_ITERATIONS;
-  const salt = crypto.randomBytes(SALT_BYTES);
+  let salt;
+  if (opts && opts.salt !== undefined) {
+    if (!Buffer.isBuffer(opts.salt) || opts.salt.length !== SALT_BYTES) {
+      throw new Error('salt must be a 32-byte Buffer');
+    }
+    salt = Buffer.from(opts.salt);
+  } else {
+    salt = crypto.randomBytes(SALT_BYTES);
+  }
   const nonce = crypto.randomBytes(NONCE_BYTES);
   const dk = deriveKey(password, salt, iterations);
   const cipher = crypto.createCipheriv(CIPHER, dk, nonce);

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const crypto = require('node:crypto');
 const path = require('node:path');
 
 const { resolve } = require('./config');
@@ -15,6 +16,7 @@ const BUNDLE_PATH = path.join(REPO_ROOT, 'lib', 'hbe.bundle.js');
 const BUNDLE_SOURCEMAP_PATH = path.join(REPO_ROOT, 'lib', 'hbe.bundle.js.map');
 
 const FORMAT_VERSION = '4';
+const STABLE_SALT_NAMESPACE = 'hexo-blog-encrypt:v4:stableSalt:';
 
 // Per-instance Symbol so user front-matter keys can never collide with our
 // idempotence marker. We deliberately do NOT use Symbol.for(...) (a global
@@ -45,6 +47,14 @@ function normalizePostTags(postTags) {
     return out;
   }
   return [];
+}
+
+function stableSaltFromPermalink(permalink) {
+  return crypto.createHash('sha256')
+    .update(STABLE_SALT_NAMESPACE)
+    .update('\0')
+    .update(permalink)
+    .digest();
 }
 
 function resolveTagPassword(hexoEncrypt, postTags) {
@@ -133,8 +143,12 @@ function register(hexo) {
     data.origin = data.content;
 
     const plaintext = String(data.content == null ? '' : data.content);
+    const stableSaltEnabled = cfg.stableSalt === true
+      && typeof data.permalink === 'string'
+      && data.permalink.length > 0;
     const { salt, nonce, ciphertext } = encrypt(plaintext, cfg.password, {
       iterations: cfg.kdf.iterations,
+      salt: stableSaltEnabled ? stableSaltFromPermalink(data.permalink) : undefined,
     });
 
     const buttonShow = !cfg.decryptButton || cfg.decryptButton.show !== false;

--- a/tests/docs.test.js
+++ b/tests/docs.test.js
@@ -186,6 +186,53 @@ test('Both READMEs explain WHY to upgrade from v3 BEFORE explaining HOW', () => 
   }
 });
 
+test('Both READMEs document stableSalt clean-build autoSave semantics', () => {
+  const cases = [
+    {
+      readme: 'ReadMe.md',
+      required: [
+        /stableSalt/,
+        /Default:\s*false|default[^.\n]*(?:false|OFF|off)/i,
+        /autoSave/,
+        /derived AES key/i,
+        /nonce[^.\n]*random|random[^.\n]*nonce/i,
+        /Cloudflare Pages/,
+        /Vercel/,
+        /Netlify/,
+        /GitHub Actions/,
+        /permalink[^.\n]*(?:changes|changed|change)|(?:changes|changed|change)[^.\n]*permalink/i,
+        /AES-GCM authentication fails[^.\n]*cache/i,
+      ],
+    },
+    {
+      readme: 'ReadMe.zh.md',
+      required: [
+        /stableSalt/,
+        /默认[:：]?\s*false|默认[^.\n]*(?:OFF|关闭|false)/i,
+        /autoSave/,
+        /AES 密钥/,
+        /nonce[^.\n]*随机|随机[^.\n]*nonce/i,
+        /Cloudflare Pages/,
+        /Vercel/,
+        /Netlify/,
+        /GitHub Actions/,
+        /permalink[^.\n]*(?:改变|变化)|(?:改变|变化)[^.\n]*permalink/i,
+        /AES-GCM 认证失败[^.\n]*缓存/,
+      ],
+    },
+  ];
+
+  for (const { readme, required } of cases) {
+    const body = read(path.join(repoRoot, readme));
+    for (const re of required) {
+      assert.ok(
+        re.test(body),
+        `${readme} must document stableSalt/autoSave semantic matching ${re}`
+      );
+    }
+  }
+});
+
 test('Both READMEs use only valid, this-repo badges (no stale legacy-fork pointers)', () => {
   // The README header lists badges. Every badge must:
   //   (1) point at THIS repository or this npm package — not the

--- a/tests/server/config.test.js
+++ b/tests/server/config.test.js
@@ -19,6 +19,7 @@ test('DEFAULTS exposes the documented v4 keys + values', () => {
   assert.equal(DEFAULTS.theme, 'default');
   assert.equal(DEFAULTS.silent, false);
   assert.equal(DEFAULTS.autoSave, false);
+  assert.equal(DEFAULTS.stableSalt, false);
   assert.equal(DEFAULTS.kdf.iterations, 250000);
   assert.equal(DEFAULTS.decryptButton.show, true);
   assert.equal(typeof DEFAULTS.decryptButton.text, 'string');
@@ -71,9 +72,16 @@ test('UNSET wrong_hash_message defaults to the resolved wrong_pass_message (sing
   assert.equal(out.wrong_hash_message, 'wrong pw!');
 });
 
-test('new keys (kdf.iterations, decryptButton.{show,text}, autoSave) honoured', () => {
+test('new keys (kdf.iterations, decryptButton.{show,text}, autoSave, stableSalt) honoured', () => {
   const out = resolve(
-    { encrypt: { kdf: { iterations: 500000 }, decryptButton: { show: false, text: 'Open' }, autoSave: true } },
+    {
+      encrypt: {
+        kdf: { iterations: 500000 },
+        decryptButton: { show: false, text: 'Open' },
+        autoSave: true,
+        stableSalt: true,
+      },
+    },
     { password: 'pw' },
     fakeLogger()
   );
@@ -81,6 +89,7 @@ test('new keys (kdf.iterations, decryptButton.{show,text}, autoSave) honoured', 
   assert.equal(out.decryptButton.show, false);
   assert.equal(out.decryptButton.text, 'Open');
   assert.equal(out.autoSave, true);
+  assert.equal(out.stableSalt, true);
 });
 
 test('kdf.iterations: 1000 THROWS with error mentioning the 100_000 floor', () => {
@@ -120,12 +129,13 @@ test('numeric password from YAML (password: 12345) is coerced to string and work
 
 test('post-data overrides hexo-config (front-matter wins)', () => {
   const out = resolve(
-    { encrypt: { theme: 'shrink', autoSave: true } },
-    { password: 'pw', theme: 'flip', autoSave: false },
+    { encrypt: { theme: 'shrink', autoSave: true, stableSalt: true } },
+    { password: 'pw', theme: 'flip', autoSave: false, stableSalt: false },
     fakeLogger()
   );
   assert.equal(out.theme, 'flip');
   assert.equal(out.autoSave, false);
+  assert.equal(out.stableSalt, false);
 });
 
 // ---------------------------------------------------------------------------

--- a/tests/server/crypto.test.js
+++ b/tests/server/crypto.test.js
@@ -30,6 +30,27 @@ test('encrypt() nonce is fresh per call (two same-input calls → different nonc
   assert.notEqual(a.nonce.toString('hex'), b.nonce.toString('hex'), 'nonces must differ');
 });
 
+test('encrypt() accepts a supplied 32-byte salt while keeping nonce fresh', () => {
+  const suppliedSalt = crypto.createHash('sha256').update('stable-permalink').digest();
+  const a = encrypt(PLAINTEXT, PASSWORD, { salt: suppliedSalt });
+  const b = encrypt(PLAINTEXT, PASSWORD, { salt: suppliedSalt });
+  assert.equal(a.salt.toString('hex'), suppliedSalt.toString('hex'));
+  assert.equal(b.salt.toString('hex'), suppliedSalt.toString('hex'));
+  assert.notEqual(a.nonce.toString('hex'), b.nonce.toString('hex'), 'nonces must remain random');
+  assert.equal(decrypt(a.salt, a.nonce, a.ciphertext, PASSWORD), PLAINTEXT);
+});
+
+test('encrypt() rejects supplied salt that is not a 32-byte Buffer', () => {
+  assert.throws(
+    () => encrypt(PLAINTEXT, PASSWORD, { salt: 'not-a-buffer' }),
+    /salt must be a 32-byte Buffer/
+  );
+  assert.throws(
+    () => encrypt(PLAINTEXT, PASSWORD, { salt: Buffer.alloc(31) }),
+    /salt must be a 32-byte Buffer/
+  );
+});
+
 test('encrypt() ciphertext length = plaintext bytes + 16 (GCM tag)', () => {
   const out = encrypt(PLAINTEXT, PASSWORD);
   const ptBytes = Buffer.byteLength(PLAINTEXT, 'utf8');

--- a/tests/server/filter.test.js
+++ b/tests/server/filter.test.js
@@ -379,6 +379,93 @@ test('per-post salt: two posts with the same password produce different salts AN
   assert.notEqual(pa.ciphertextHex, pb.ciphertextHex, 'ciphertext must differ');
 });
 
+test('stableSalt defaults off: same permalink built twice still produces different salts', async () => {
+  hexo.config.encrypt = {};
+  const opts = {
+    title: 'stable-default-off',
+    password: 'shared',
+    content: '<p>same</p>',
+    permalink: 'https://example.test/stable-default-off/',
+  };
+  const a = makeSyntheticData(opts);
+  const b = makeSyntheticData(opts);
+
+  await hexo.execFilter('after_post_render', a, { context: hexo });
+  await hexo.execFilter('after_post_render', b, { context: hexo });
+
+  const pa = extractPayload(a.content);
+  const pb = extractPayload(b.content);
+  assert.notEqual(pa.saltHex, pb.saltHex, 'stableSalt defaults off, so salt must remain random');
+});
+
+test('stableSalt opt-in: same permalink built twice reuses salt but not nonce', async () => {
+  hexo.config.encrypt = { stableSalt: true };
+  const opts = {
+    title: 'stable-on',
+    password: 'shared',
+    content: '<p>same</p>',
+    permalink: 'https://example.test/stable-on/',
+  };
+  const a = makeSyntheticData(opts);
+  const b = makeSyntheticData(opts);
+
+  await hexo.execFilter('after_post_render', a, { context: hexo });
+  await hexo.execFilter('after_post_render', b, { context: hexo });
+
+  const pa = extractPayload(a.content);
+  const pb = extractPayload(b.content);
+  assert.equal(pa.saltHex, pb.saltHex, 'same permalink must derive the same stable salt');
+  assert.notEqual(pa.nonceHex, pb.nonceHex, 'nonce must remain random');
+  assert.notEqual(pa.ciphertextHex, pb.ciphertextHex, 'fresh nonce keeps ciphertext different');
+  assert.ok(decryptHbeV4({ password: 'shared', ...pa }).includes('<p>same</p>'));
+  assert.ok(decryptHbeV4({ password: 'shared', ...pb }).includes('<p>same</p>'));
+});
+
+test('stableSalt opt-in: different permalinks produce different salts', async () => {
+  hexo.config.encrypt = { stableSalt: true };
+  const a = makeSyntheticData({
+    title: 'stable-a',
+    password: 'shared',
+    content: '<p>same</p>',
+    permalink: 'https://example.test/stable-a/',
+  });
+  const b = makeSyntheticData({
+    title: 'stable-b',
+    password: 'shared',
+    content: '<p>same</p>',
+    permalink: 'https://example.test/stable-b/',
+  });
+
+  await hexo.execFilter('after_post_render', a, { context: hexo });
+  await hexo.execFilter('after_post_render', b, { context: hexo });
+
+  const pa = extractPayload(a.content);
+  const pb = extractPayload(b.content);
+  assert.notEqual(pa.saltHex, pb.saltHex, 'permalink is the stable salt identity');
+});
+
+test('stableSalt opt-in without a non-empty permalink falls back to random salt', async () => {
+  hexo.config.encrypt = { stableSalt: true };
+  const a = makeSyntheticData({ title: 'stable-no-permalink-a', password: 'shared', content: '<p>same</p>' });
+  const b = makeSyntheticData({ title: 'stable-no-permalink-b', password: 'shared', content: '<p>same</p>' });
+  const c = makeSyntheticData({
+    title: 'stable-empty-permalink',
+    password: 'shared',
+    content: '<p>same</p>',
+    permalink: '',
+  });
+
+  await hexo.execFilter('after_post_render', a, { context: hexo });
+  await hexo.execFilter('after_post_render', b, { context: hexo });
+  await hexo.execFilter('after_post_render', c, { context: hexo });
+
+  const pa = extractPayload(a.content);
+  const pb = extractPayload(b.content);
+  const pc = extractPayload(c.content);
+  assert.notEqual(pa.saltHex, pb.saltHex, 'missing permalink cannot derive stable salt');
+  assert.notEqual(pa.saltHex, pc.saltHex, 'empty permalink cannot derive stable salt');
+});
+
 // ---------------------------------------------------------------------------
 // v4 NEW: per-encryption nonce — same content built twice → different nonce/ciphertext
 // ---------------------------------------------------------------------------

--- a/tests/server/storage.test.js
+++ b/tests/server/storage.test.js
@@ -1,0 +1,78 @@
+'use strict';
+
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+
+const storage = require('../../src/browser/storage');
+
+const PAGE_KEY = '/autosave-default/';
+const SALT_A = '00'.repeat(32);
+const SALT_B = '11'.repeat(32);
+const NONCE_A = '22'.repeat(12);
+const NONCE_B = '33'.repeat(12);
+const RAW_KEY = new Uint8Array(32).fill(7);
+
+function makeLocalStorage() {
+  const store = new Map();
+  return {
+    _store: store,
+    getItem: (key) => store.has(key) ? store.get(key) : null,
+    setItem: (key, value) => { store.set(key, String(value)); },
+    removeItem: (key) => { store.delete(key); },
+  };
+}
+
+async function makeKey() {
+  return crypto.subtle.importKey(
+    'raw',
+    RAW_KEY,
+    { name: 'AES-GCM' },
+    true,
+    ['decrypt']
+  );
+}
+
+async function saveFixtureEntry() {
+  await storage.save({
+    pageKey: PAGE_KEY,
+    key: await makeKey(),
+    saltHex: SALT_A,
+    nonceHex: NONCE_A,
+    autoSave: true,
+  });
+}
+
+async function assertLoadedKeyMatches(loaded) {
+  assert.ok(loaded, 'expected cached key to load');
+  const raw = new Uint8Array(await crypto.subtle.exportKey('raw', loaded));
+  assert.deepEqual(raw, RAW_KEY);
+}
+
+test('storage.load returns cached key when salt matches, even if stored nonce is stale', async () => {
+  global.localStorage = makeLocalStorage();
+  await saveFixtureEntry();
+  const rawEntry = JSON.parse(global.localStorage._store.get('hbe.v4.' + PAGE_KEY));
+  assert.equal(rawEntry.nonce, NONCE_A);
+
+  const loaded = await storage.load({
+    pageKey: PAGE_KEY,
+    expectedSaltHex: SALT_A,
+    expectedNonceHex: NONCE_B,
+  });
+
+  await assertLoadedKeyMatches(loaded);
+  assert.equal(global.localStorage._store.size, 1);
+});
+
+test('storage.load clears salt mismatch', async () => {
+  global.localStorage = makeLocalStorage();
+  await saveFixtureEntry();
+
+  const loaded = await storage.load({
+    pageKey: PAGE_KEY,
+    expectedSaltHex: SALT_B,
+  });
+
+  assert.equal(loaded, null);
+  assert.equal(global.localStorage._store.size, 0);
+});


### PR DESCRIPTION
Issue Fixed #233 

## Proposed Changes

本 PR 包括以下三个 commits，并且已经在我的博客（index545.com）测试过运行良好。

- a55b44b，这是对于前端的更改，而且我更愿意称之为 `fix` 而不是 `feat`。得益于前端之前的出色架构，添加 stableSalt 功能实际上几乎没有产生任何变化，先前的校验逻辑会同时检查 salt 和 nonce，但实际上 localStorage 中存储的本身就是派生 key（这只和 password 和 salt 有关）并且其中存储的 nonce 事实上没有起到任何作用——代码在任何时候都不会使用它（不过出于兼容性考虑我没有移除它），所以我所做的更改只是忽略存储的 nonce——这对于善意用户和攻击者应该都不会产生任何影响。
- 9d906e0，这是对于后端的更改，添加了默认为 false 的 stableSalt 选项，在启用时，文章将使用 permanent link 的 hash 作为 salt，而不是随机串。nonce 始终随机生成。
- 2e3dd3e，这是文档的更改，主要是 GPT 写的，不过我校对过，而且愿意为内容承担责任。

---

This PR consists of the following three commits, and has been tested on my blog, `index545.com`, where it works well. The English description below was translated from my original Chinese text with the help of ChatGPT.

- `a55b44b`: Frontend changes. I would prefer to classify this as a `fix` rather than a `feat`. Thanks to the frontend’s already well-designed architecture, adding support for `stableSalt` required almost no actual changes. The previous validation logic checked both the salt and the nonce, but the value stored in `localStorage` is in fact the derived key, which depends only on the password and the salt. The stored nonce was not actually used anywhere in the code. For compatibility reasons, I did not remove it; instead, the change simply ignores the stored nonce. This should have no practical impact on either legitimate users or attackers.
- `9d906e0`: Backend changes. This adds a `stableSalt` option, which defaults to `false`. When enabled, articles use the hash of the permanent link as the salt instead of a random string. The nonce is still always generated randomly.
- `2e3dd3e`: Documentation changes. The documentation was mainly drafted with the help of GPT, but I have carefully reviewed it and stand by its contents.

## Checklist

- [x] Ran `npm run test` locally and it passed
- [x] If adding a theme, included all 7 `{{hbe...}}` placeholders and 5 `data-*` attrs (see `docs/THEMES.md`)
- [x] Did not modify `index.js` or `lib/hbe.js` server↔browser crypto without updating both halves