### PR TITLE
test: stableSalt clean-rebuild e2e regression + v4.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,31 @@ project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
+## [4.0.2] — 2026-06-07
+
+### Tests
+
+* **`stableSalt` clean-rebuild e2e regression** — added end-to-end coverage
+  for the headline `stableSalt` guarantee that previously had none. With
+  `stableSalt: true` + `autoSave: true`, a clean static rebuild re-emits the
+  same permalink-derived salt but a **fresh** nonce and ciphertext. A new
+  Playwright test seeds the `localStorage` key cache from one build, then
+  simulates a rebuild (re-encrypting the same plaintext under the same salt
+  via the server crypto, yielding a new nonce/ciphertext) and asserts the
+  cached key still auto-decrypts the new payload (`mode="cached"`, no
+  re-prompt). A companion self-heal test proves that when the salt itself
+  changes (permalink change / `stableSalt` off), `storage.load()` drops the
+  stale entry and the visitor is re-prompted. New fixture
+  `templates/stablesalt-post.md` → `stablesalt-default.md`. No runtime or
+  crypto behavior changed — tests and docs only.
+
+### Docs
+
+* Refreshed the wiki and in-repo docs to describe `stableSalt`, correct the
+  per-post salt size (32 bytes), and note the deterministic-salt tradeoff.
+
+---
+
 ## [4.0.1] — 2026-05-19
 
 ### Fixed

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -67,6 +67,13 @@ not clear solely because the cached nonce differs; decryption always uses
 the current page's `data-nonce` and ciphertext. If AES-GCM authentication
 fails, the cache is cleared and the password form remains visible.
 
+The Playwright e2e suite (`tests/e2e/decryption.spec.js`) guards this
+clean-rebuild path directly: with `stableSalt` + `autoSave` on, it seeds
+the cache, simulates a rebuild (same salt, fresh nonce + ciphertext via the
+server crypto) over the reload, and asserts the cached key still
+auto-decrypts (`mode="cached"`); a companion test asserts the salt-change
+self-heal re-prompts.
+
 ## Code conventions
 
 - **Node CommonJS** (`require` / `module.exports`) on the server side; no

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "test:docs": "node --test tests/docs.test.js",
     "lint": "eslint --ext .js ./"
   },
-  "version": "4.0.1",
+  "version": "4.0.2",
   "engines": {
     "node": ">=18"
   },

--- a/tests/e2e/decryption.spec.js
+++ b/tests/e2e/decryption.spec.js
@@ -31,9 +31,11 @@
 
 const fs = require('fs');
 const path = require('path');
+const crypto = require('node:crypto');
 
 const { test, expect } = require('./fixtures');
 const { discoverThemes } = require('../helpers/buildSite');
+const { encrypt, decrypt } = require('../../src/server/crypto');
 
 const THEMES_FILE = path.join(__dirname, '.themes.json');
 const themes = fs.existsSync(THEMES_FILE)
@@ -300,6 +302,168 @@ test.describe('v4 UX (single-theme)', () => {
         .filter((k) => k.startsWith('hbe.v4.'))
         .forEach((k) => localStorage.removeItem(k));
     });
+  });
+
+  // ─────────────────────────────────────────────────────────────────────
+  // stableSalt clean-rebuild regression (issue #233 / PR #234).
+  //
+  // The WHOLE point of `stableSalt: true` is that a clean static rebuild
+  // (Cloudflare Pages / Vercel / Netlify / GitHub Actions) re-emits the
+  // SAME permalink-derived salt but a FRESH random nonce + ciphertext.
+  // A derived key cached in localStorage from the PREVIOUS build depends
+  // only on (password, salt, iterations) — so it must still auto-decrypt
+  // the new payload. The existing autoSave test only reloads the SAME
+  // static HTML (salt AND nonce unchanged), so it never exercises this.
+  //
+  // The site is built once in globalSetup, so we SIMULATE the rebuild:
+  // read the real wire (salt/nonce/ciphertext) from the page, re-encrypt
+  // the SAME plaintext under the SAME salt via the server crypto (giving a
+  // fresh nonce + ciphertext, exactly like a rebuild), then `page.route()`
+  // the reload to serve that rebuilt payload. data-salt is left unchanged.
+  //
+  // NOTE: data-salt MUST be captured BEFORE the manual decrypt — on
+  // success `dom.js` replaces the wrapper <div> with a fresh node that
+  // carries no data-salt/data-nonce, so reading it afterwards yields null.
+  // ─────────────────────────────────────────────────────────────────────
+  test('stableSalt clean-rebuild: cached key auto-decrypts a fresh nonce/ciphertext (mode="cached")', async ({ page }) => {
+    await page.goto('/stablesalt-default/');
+
+    // Capture the wire BEFORE decrypt (the wrapper is destroyed on reveal).
+    const wire = await page.evaluate(() => {
+      const el = document.getElementById('hexo-blog-encrypt');
+      return {
+        saltHex: el.dataset.salt,
+        nonceHex: el.dataset.nonce,
+        ciphertextHex: el.querySelector('script#hbeData').textContent.trim(),
+      };
+    });
+    expect(wire.saltHex, 'data-salt must be 32-byte hex').toMatch(/^[0-9a-f]{64}$/);
+
+    // 1) Manual decrypt → seeds the localStorage cache with the derived key.
+    const firstMode = listenForDecryptMode(page);
+    await page.locator('#hbePass').fill(PASSWORD);
+    await page.locator('#hbePass').press('Enter');
+    expect(await firstMode).toBe('manual');
+    await expect(page.locator('body')).toContainText(SECRET);
+
+    // The cached entry's salt must match the page salt we captured.
+    const cachedSalt = await page.evaluate(() => {
+      const k = Object.keys(localStorage).find((x) => x.startsWith('hbe.v4.'));
+      return k ? JSON.parse(localStorage.getItem(k)).salt : null;
+    });
+    expect(cachedSalt, 'cached salt must equal the page salt').toBe(wire.saltHex);
+
+    // 2) Simulate a clean rebuild: recover the exact plaintext, then
+    //    re-encrypt under the SAME salt → same salt, fresh nonce/ciphertext.
+    const plaintext = decrypt(
+      Buffer.from(wire.saltHex, 'hex'),
+      Buffer.from(wire.nonceHex, 'hex'),
+      Buffer.from(wire.ciphertextHex, 'hex'),
+      PASSWORD
+    );
+    const rebuilt = encrypt(plaintext, PASSWORD, { salt: Buffer.from(wire.saltHex, 'hex') });
+    const rebuiltNonceHex = rebuilt.nonce.toString('hex');
+    const rebuiltCiphertextHex = rebuilt.ciphertext.toString('hex');
+    expect(rebuilt.salt.toString('hex'), 'rebuild keeps the salt').toBe(wire.saltHex);
+    expect(rebuiltNonceHex, 'rebuild mints a fresh nonce').not.toBe(wire.nonceHex);
+    expect(rebuiltCiphertextHex, 'fresh nonce ⇒ fresh ciphertext').not.toBe(wire.ciphertextHex);
+
+    // 3) Serve the rebuilt payload on the reload (data-salt untouched).
+    await page.route('**/stablesalt-default/**', async (route) => {
+      const response = await route.fetch();
+      let body = await response.text();
+      body = body
+        .replace(`data-nonce="${wire.nonceHex}"`, `data-nonce="${rebuiltNonceHex}"`)
+        .replace(wire.ciphertextHex, rebuiltCiphertextHex);
+      await route.fulfill({ response, body });
+    });
+
+    // 4) Capture the auto-decrypt mode across the navigation, then reload.
+    await page.addInitScript(() => {
+      window.__hbeAutoMode = null;
+      window.addEventListener('hexo-blog-decrypt', (e) => {
+        window.__hbeAutoMode = (e && e.detail && e.detail.mode) || 'legacy';
+      });
+    });
+    await page.reload();
+
+    // 5) No password interaction — the cached key decrypts the NEW payload.
+    await expect.poll(
+      () => page.evaluate(() => window.__hbeAutoMode),
+      { timeout: 3000 }
+    ).toBe('cached');
+    await expect(page.locator('body')).toContainText(SECRET);
+
+    await page.evaluate(() => {
+      Object.keys(localStorage)
+        .filter((k) => k.startsWith('hbe.v4.'))
+        .forEach((k) => localStorage.removeItem(k));
+    });
+  });
+
+  // ─────────────────────────────────────────────────────────────────────
+  // Self-heal companion: if the salt itself changes (permalink changed, or
+  // stableSalt turned off so a random salt is minted), the cached key is
+  // stale. storage.load() drops it on salt mismatch and the visitor is
+  // re-prompted — never silently stuck on a key that can't decrypt.
+  // ─────────────────────────────────────────────────────────────────────
+  test('stableSalt self-heal: salt change clears the cache and re-prompts (no mode="cached")', async ({ page }) => {
+    await page.goto('/stablesalt-default/');
+
+    const wire = await page.evaluate(() => {
+      const el = document.getElementById('hexo-blog-encrypt');
+      return {
+        saltHex: el.dataset.salt,
+        nonceHex: el.dataset.nonce,
+        ciphertextHex: el.querySelector('script#hbeData').textContent.trim(),
+      };
+    });
+
+    // Seed the cache with a key bound to the ORIGINAL salt.
+    const firstMode = listenForDecryptMode(page);
+    await page.locator('#hbePass').fill(PASSWORD);
+    await page.locator('#hbePass').press('Enter');
+    expect(await firstMode).toBe('manual');
+    await expect(page.locator('body')).toContainText(SECRET);
+
+    // Simulate a rebuild that minted a DIFFERENT salt (permalink changed,
+    // or stableSalt off) while leaving the ORIGINAL nonce + ciphertext in
+    // place. This is deliberate: rewriting ONLY data-salt makes the test
+    // *discriminating*. Under correct code, storage.load() rejects the
+    // cached key on the salt mismatch BEFORE any decrypt, so the visitor is
+    // re-prompted. Under a regression where load() stopped gating on salt,
+    // the still-cached key would successfully decrypt the untouched original
+    // ciphertext → mode="cached" → these assertions fail and catch it.
+    // (Re-encrypting under the new salt instead would let such a regression
+    // pass, because the stale key would merely hit a GCM failure that
+    // main.js also cleans up — an indistinguishable end state.)
+    const newSaltHex = crypto.randomBytes(32).toString('hex');
+    expect(newSaltHex, 'self-heal setup needs a different salt').not.toBe(wire.saltHex);
+
+    await page.route('**/stablesalt-default/**', async (route) => {
+      const response = await route.fetch();
+      let body = await response.text();
+      body = body.replace(`data-salt="${wire.saltHex}"`, `data-salt="${newSaltHex}"`);
+      await route.fulfill({ response, body });
+    });
+
+    await page.addInitScript(() => {
+      window.__hbeAutoMode = null;
+      window.addEventListener('hexo-blog-decrypt', (e) => {
+        window.__hbeAutoMode = (e && e.detail && e.detail.mode) || 'legacy';
+      });
+    });
+    await page.reload();
+
+    // The password form is shown again (salt-mismatched key was dropped).
+    await expect(page.locator('#hbePass')).toBeVisible();
+    // Auto-decrypt never fired, and the secret is NOT auto-revealed.
+    expect(await page.evaluate(() => window.__hbeAutoMode)).toBeNull();
+    await expect(page.locator('body')).not.toContainText(SECRET);
+    // The stale cache entry was cleared by storage.load() on the mismatch.
+    expect(await page.evaluate(
+      () => Object.keys(localStorage).filter((k) => k.startsWith('hbe.v4.')).length
+    )).toBe(0);
   });
 
   test('legacy event listener (no detail access) still fires', async ({ page }) => {

--- a/tests/fixtures/hexo-site/.gitignore
+++ b/tests/fixtures/hexo-site/.gitignore
@@ -4,4 +4,5 @@ db.json
 .deploy_git/
 source/_posts/encrypted-*.md
 source/_posts/autosave-*.md
+source/_posts/stablesalt-*.md
 source/_posts/tag-only-*.md

--- a/tests/fixtures/hexo-site/templates/stablesalt-post.md
+++ b/tests/fixtures/hexo-site/templates/stablesalt-post.md
@@ -1,0 +1,21 @@
+---
+title: Stable-salt Post (default)
+date: 2024-01-03 00:00:00
+encrypt: true
+password: hello
+theme: default
+autoSave: true
+stableSalt: true
+---
+
+This is the public preview text. Below the cut is the secret.
+
+<!-- more -->
+
+# Secret content for theme default (stableSalt + autosave on)
+
+THE SECRET IS BUTTERFLY
+
+```js
+const x = 42;
+```

--- a/tests/helpers/buildSite.js
+++ b/tests/helpers/buildSite.js
@@ -8,6 +8,7 @@ const REPO_ROOT = path.resolve(__dirname, '..', '..');
 const DEFAULT_FIXTURE = path.join(REPO_ROOT, 'tests', 'fixtures', 'hexo-site');
 const TEMPLATE_REL = path.join('templates', 'encrypted-post.md');
 const AUTOSAVE_TEMPLATE_REL = path.join('templates', 'autosave-post.md');
+const STABLESALT_TEMPLATE_REL = path.join('templates', 'stablesalt-post.md');
 const TAG_ONLY_TEMPLATE_REL = path.join('templates', 'tag-encrypted-post.md');
 const CALLBACK_TEMPLATE_REL = path.join('templates', 'callback-post.md');
 const NON_ASCII_BUTTON_TEMPLATE_REL = path.join('templates', 'non-ascii-button-post.md');
@@ -77,6 +78,18 @@ function materializePosts(fixtureDir, themes) {
   const autosaveDest = path.join(postsDir, 'autosave-default.md');
   fs.writeFileSync(autosaveDest, autosaveBody, 'utf8');
   written.push(autosaveDest);
+
+  // Single stableSalt-on post (default theme only) — used by the
+  // stableSalt clean-rebuild e2e regression. Combines `autoSave: true`
+  // with `stableSalt: true` so the e2e can prove that a key cached from
+  // a previous build still auto-decrypts a fresh nonce/ciphertext as
+  // long as the (permalink-derived) salt is unchanged.
+  const stableSaltTemplatePath = path.join(fixtureDir, STABLESALT_TEMPLATE_REL);
+  const stableSaltBody = fs.readFileSync(stableSaltTemplatePath, 'utf8')
+    .split('__THEME__').join('default');
+  const stableSaltDest = path.join(postsDir, 'stablesalt-default.md');
+  fs.writeFileSync(stableSaltDest, stableSaltBody, 'utf8');
+  written.push(stableSaltDest);
 
   // Single tag-only-encrypted post (default theme) — no front-matter
   // password; encryption is driven by `_config.yml.encrypt.tags`. This


### PR DESCRIPTION
## Why

`stableSalt` (#234) shipped without end-to-end coverage of its **headline guarantee**: with `stableSalt: true` + `autoSave: true`, a key cached in `localStorage` from a previous clean build must still auto-decrypt after a rebuild re-emits the **same** permalink-derived salt but a **fresh** nonce + ciphertext.

The existing autoSave e2e (`autoSave opt-in: reload auto-decrypts…`) only reloads the **same** static HTML — salt *and* nonce unchanged — so it never exercised the salt-stable / nonce-changed path that is the entire point of the feature. This PR closes that gap.

## What

New fixture `templates/stablesalt-post.md` → `stablesalt-default.md` (`stableSalt: true` + `autoSave: true`), materialized by `buildSite.js`, plus **two Playwright tests** in `tests/e2e/decryption.spec.js`:

- **clean-rebuild** — seed the cache via manual decrypt, then simulate a rebuild by re-encrypting the *same* plaintext under the *same* salt with the server crypto (yielding a fresh nonce + ciphertext), serve that over the reload via `page.route()`, and assert the cached key still auto-decrypts (`mode="cached"`, no re-prompt). `data-salt` is captured **before** decrypt because `dom.js` replaces the wrapper on reveal.
- **self-heal** — rewrite **only** `data-salt` to a fresh salt (leaving the original nonce/ciphertext intact) so the test is *discriminating*: under correct code `storage.load()` drops the stale key on salt mismatch and re-prompts; a salt-ignoring regression would instead decrypt the untouched ciphertext and fail the test.

Both were validated by **mutation testing**:
- clean-rebuild fails under the pre-#234 salt+nonce invalidation (`Expected "cached", Received null`).
- self-heal fails under a salt-ignoring `storage.load()` regression.

## Not changed

No runtime / crypto / `src/` change — **tests + docs only**. `src/` diff is empty.

## Release

- `package.json` → **4.0.2**
- `CHANGELOG.md` → dated `## [4.0.2] — 2026-06-07` entry (satisfies the changelog-tag gate)
- `docs/ARCHITECTURE.md` → notes the new e2e coverage of the rebuild path
- Wiki updated separately (stableSalt section, 16→32-byte salt fix, refreshed test counts)

## Test results (local)

- **Lint:** clean · **Server:** 158/158 · **E2E:** 44/44 (incl. the 2 new tests)

> Note: `npm run test`'s `test:server` step uses **c8@10**, which is incompatible with Node 26 on the dev machine (`yargs` ESM error — reproduces on clean `master`, unrelated to this diff). Gates were run directly (`node --test` + Playwright); CI on Node 18/20 runs `npm run test` normally.

## Checklist

- [x] Ran the suite locally (lint + server + e2e) and it passed
- [x] Did not modify `index.js` or `lib/hbe.js` server↔browser crypto (no source change at all)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
